### PR TITLE
feat: #22 Add workflow for comparing versions of R repos

### DIFF
--- a/.github/workflows/R-semver-check.yml
+++ b/.github/workflows/R-semver-check.yml
@@ -42,17 +42,10 @@ jobs:
         with:
           use-public-rspm: true
 
-      - name: Install dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          cache: true
-          dependencies: 'FALSE'
-          extra-packages: |
-            desc
-
       - name: compare versions
         run: |
           Rscript -e ' \
+            install.packages("desc"); \
             working_version <- desc::desc_get_version("working/DESCRIPTION"); \
             message("working version: ", working_version); \
             compare_version <- desc::desc_get_version("compare/DESCRIPTION"); \

--- a/.github/workflows/R-semver-check.yml
+++ b/.github/workflows/R-semver-check.yml
@@ -16,7 +16,6 @@ jobs:
     steps:
 
       - name: checkout working HEAD
-        if: steps.changed-package-files.outputs.any_changed == 'false'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
@@ -25,7 +24,6 @@ jobs:
           path: working
 
       - name: checkout base HEAD
-        if: steps.changed-package-files.outputs.any_changed == 'false'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.ref }}
@@ -34,7 +32,6 @@ jobs:
           path: compare
 
       - name: show files
-        if: steps.changed-package-files.outputs.any_changed == 'false'
         run: |
           ls -lR working compare
           echo "\nWORKING:\n"
@@ -43,13 +40,11 @@ jobs:
           cat compare/DESCRIPTION
 
       - name: Setup R
-        if: steps.changed-package-files.outputs.any_changed == 'false'
         uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
       - name: compare versions
-        if: steps.changed-package-files.outputs.any_changed == 'false'
         run: |
           Rscript -e " \
             install.packages('desc'); \

--- a/.github/workflows/R-semver-check.yml
+++ b/.github/workflows/R-semver-check.yml
@@ -1,0 +1,62 @@
+---
+on:
+  workflow_call:
+
+name: Version check
+
+jobs:
+  version-check:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ github.token }}
+
+    steps:
+
+      - name: checkout working HEAD
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          sparse-checkout: |
+            DESCRIPTION
+          path: working
+
+      - name: checkout base HEAD
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          sparse-checkout: |
+            DESCRIPTION
+          path: compare
+
+      - name: show files
+        run: |
+          ls -laR working compare
+          cat working/DESCRIPTION
+          cat compare/DESCRIPTION
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          cache: true
+          dependencies: 'FALSE'
+          extra-packages: |
+            desc
+
+      - name: compare versions
+        run: |
+          Rscript -e ' \
+            working_version <- desc::desc_get_version("working/DESCRIPTION"); \
+            message("working version: ", working_version); \
+            compare_version <- desc::desc_get_version("compare/DESCRIPTION"); \
+            message("compare version: ", compare_version); \
+            stopifnot(working_version > compare_version); \
+          '
+
+
+          '

--- a/.github/workflows/R-semver-check.yml
+++ b/.github/workflows/R-semver-check.yml
@@ -44,11 +44,11 @@ jobs:
 
       - name: compare versions
         run: |
-          Rscript -e ' \
-            install.packages("desc"); \
-            working_version <- desc::desc_get_version("working/DESCRIPTION"); \
-            message("working version: ", working_version); \
-            compare_version <- desc::desc_get_version("compare/DESCRIPTION"); \
-            message("compare version: ", compare_version); \
+          Rscript -e " \
+            install.packages('desc'); \
+            working_version <- desc::desc_get_version('working/DESCRIPTION'); \
+            message('working version: ', working_version); \
+            compare_version <- desc::desc_get_version('compare/DESCRIPTION'); \
+            message('compare version: ', compare_version); \
             stopifnot(working_version > compare_version); \
-          '
+          "

--- a/.github/workflows/R-semver-check.yml
+++ b/.github/workflows/R-semver-check.yml
@@ -10,10 +10,42 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ github.token }}
+    permissions:
+      pull_request: read
 
     steps:
 
+      - name: Get all changed R package files
+        id: changed-package-files
+        uses: tj-actions/changed-files@v42
+        with:
+          base_sha: ${{ github.event.pull_request.base.sha }}
+          # Avoid using single or double quotes for multiline patterns
+          files: |
+             **.R
+             DESCRIPTION
+             LICENSE
+             LICENSE.md
+             NAMESPACE
+             R/**
+             data/**
+             inst/**
+             src/**
+             vignettes/**
+
+      - name: No changed R files
+        if: steps.changed-package-files.outputs.any_changed == 'true'
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-package-files.outputs.all_changed_files }}
+        run: |
+          echo "No Changed R files."
+          echo "Files changed in this PR:"
+          for file in ${ALL_CHANGED_FILES}; do
+            echo "$file"
+          done
+
       - name: checkout working HEAD
+        if: steps.changed-package-files.outputs.any_changed == 'false'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
@@ -22,6 +54,7 @@ jobs:
           path: working
 
       - name: checkout base HEAD
+        if: steps.changed-package-files.outputs.any_changed == 'false'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.ref }}
@@ -30,6 +63,7 @@ jobs:
           path: compare
 
       - name: show files
+        if: steps.changed-package-files.outputs.any_changed == 'false'
         run: |
           ls -lR working compare
           echo "\nWORKING:\n"
@@ -38,11 +72,13 @@ jobs:
           cat compare/DESCRIPTION
 
       - name: Setup R
+        if: steps.changed-package-files.outputs.any_changed == 'false'
         uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
       - name: compare versions
+        if: steps.changed-package-files.outputs.any_changed == 'false'
         run: |
           Rscript -e " \
             install.packages('desc'); \

--- a/.github/workflows/R-semver-check.yml
+++ b/.github/workflows/R-semver-check.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ github.token }}
     permissions:
-      pull_request: read
+      pull-requests: read
 
     steps:
 

--- a/.github/workflows/R-semver-check.yml
+++ b/.github/workflows/R-semver-check.yml
@@ -32,7 +32,9 @@ jobs:
       - name: show files
         run: |
           ls -lR working compare
+          echo "\nWORKING:\n"
           cat working/DESCRIPTION
+          echo "\nCOMPARE:\n"
           cat compare/DESCRIPTION
 
       - name: Setup R

--- a/.github/workflows/R-semver-check.yml
+++ b/.github/workflows/R-semver-check.yml
@@ -52,6 +52,3 @@ jobs:
             message("compare version: ", compare_version); \
             stopifnot(working_version > compare_version); \
           '
-
-
-          '

--- a/.github/workflows/R-semver-check.yml
+++ b/.github/workflows/R-semver-check.yml
@@ -15,35 +15,6 @@ jobs:
 
     steps:
 
-      - name: Get all changed R package files
-        id: changed-package-files
-        uses: tj-actions/changed-files@v42
-        with:
-          base_sha: ${{ github.event.pull_request.base.sha }}
-          # Avoid using single or double quotes for multiline patterns
-          files: |
-             **.R
-             DESCRIPTION
-             LICENSE
-             LICENSE.md
-             NAMESPACE
-             R/**
-             data/**
-             inst/**
-             src/**
-             vignettes/**
-
-      - name: No changed R files
-        if: steps.changed-package-files.outputs.any_changed == 'true'
-        env:
-          ALL_CHANGED_FILES: ${{ steps.changed-package-files.outputs.all_changed_files }}
-        run: |
-          echo "No Changed R files."
-          echo "Files changed in this PR:"
-          for file in ${ALL_CHANGED_FILES}; do
-            echo "$file"
-          done
-
       - name: checkout working HEAD
         if: steps.changed-package-files.outputs.any_changed == 'false'
         uses: actions/checkout@v4

--- a/.github/workflows/R-semver-check.yml
+++ b/.github/workflows/R-semver-check.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: show files
         run: |
-          ls -laR working compare
+          ls -lR working compare
           cat working/DESCRIPTION
           cat compare/DESCRIPTION
 

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -67,7 +67,7 @@ jobs:
       error-on: ${{ inputs.r-cmd-check-error-on }}
 
   version-check:
-    if: ${{ inputs.do-compare-versions && needs.check-R-updates.outputs.any_changed }}
+    if: ${{ inputs.do-compare-versions && needs.check-R-updates.outputs.any_changed == TRUE }}
     needs: [check-R-updates]
     uses: ./.github/workflows/R-semver-check.yml
 

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: true
         type: boolean
+      do-compare-versions:
+        description: 'Flag to compare versions in DESCRIPTION'
+        required: false
+        default: true
+        type: boolean
       r-cmd-check-error-on:
         description: 'Level of R CMD CHECK issue to fail check'
         required: false
@@ -40,3 +45,8 @@ jobs:
     uses: ./.github/workflows/R-CMD-check.yml
     with:
       error-on: ${{ inputs.r-cmd-check-error-on }}
+
+  version-check:
+    if: ${{ inputs.do-compare-versions }}
+    uses: ./.github/workflows/R-semver-check.yml
+

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -37,6 +37,21 @@ on:
 
 jobs:
 
+  check-R-updates:
+    uses: ./.github/workflows/check-updated-files.yml
+    with:
+      files: |
+        **.R
+        DESCRIPTION
+        LICENSE
+        LICENSE.md
+        NAMESPACE
+        R/**
+        data/**
+        inst/**
+        src/**
+        vignettes/**
+
   lintr:
     if: ${{ inputs.do-lint }}
     uses: ./.github/workflows/R-lintr.yml
@@ -52,7 +67,8 @@ jobs:
       error-on: ${{ inputs.r-cmd-check-error-on }}
 
   version-check:
-    if: ${{ inputs.do-compare-versions }}
+    if: ${{ inputs.do-compare-versions && needs.check-R-updates.outputs.any_changed }}
+    needs: [check-R-updates]
     uses: ./.github/workflows/R-semver-check.yml
 
   docs-check:

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -67,7 +67,7 @@ jobs:
       error-on: ${{ inputs.r-cmd-check-error-on }}
 
   version-check:
-    if: ${{ inputs.do-compare-versions && needs.check-R-updates.outputs.any_changed == TRUE }}
+    if: ${{ inputs.do-compare-versions && needs.check-R-updates.outputs.any_changed == 'true' }}
     needs: [check-R-updates]
     uses: ./.github/workflows/R-semver-check.yml
 

--- a/.github/workflows/check-updated-files.yml
+++ b/.github/workflows/check-updated-files.yml
@@ -56,8 +56,11 @@ jobs:
 
       - name: List all changed files
         env:
-          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+          ALL_MODIFIED_FILES: ${{ steps.changed-files.outputs.all_modified_files }}
+          ANY_CHANGED: ${{ steps.changed-files.outputs.any_changed }}
         run: |
-          for file in ${ALL_CHANGED_FILES}; do
-            echo "$file was changed"
+          echo "Any Changed: $ANY_CHANGED"
+          echo ""
+          for file in ${ALL_MODIFIED_FILES}; do
+            echo "$file was modified"
           done

--- a/.github/workflows/check-updated-files.yml
+++ b/.github/workflows/check-updated-files.yml
@@ -46,10 +46,18 @@ jobs:
         with:
           fetch-depth: ${{ inputs.fetch-depth }}
 
-      - name: Get all changed R package files
+      - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v42
         with:
           base_sha: ${{ inputs.base_sha }}
           # Avoid using single or double quotes for multiline patterns
           files: ${{ inputs.files }}
+
+      - name: List all changed files
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          for file in ${ALL_CHANGED_FILES}; do
+            echo "$file was changed"
+          done

--- a/.github/workflows/check-updated-files.yml
+++ b/.github/workflows/check-updated-files.yml
@@ -1,0 +1,55 @@
+---
+on:
+  workflow_call:
+    inputs:
+      fetch-depth:
+        description: 'fetch-depth for checkout (default: 0, get entire history). 2 retrieves preceeding commit.'
+        required: false
+        default: 0
+        type: number
+      files:
+        description: 'File paths to check for changes'
+        required: true
+        type: string
+      base_sha:
+        description: 'Base SHA to use for comparison'
+        required: true
+        type: string
+        default: |
+          ${{
+            github.event_name == 'pull_request' && github.event.pull_request.base.sha ||
+            github.event_name == 'push' && github.event.push.before ||
+            ''
+          }}
+    outputs:
+      any_changed:
+        description: "true/false if any files named in `files` input have changed"
+        value: ${{ jobs.updated-files.outputs.any_changed }}
+      all_modified_files:
+        description: "list of all modified files"
+        value: ${{ jobs.updated-files.outputs.all_modified_files }}
+
+name: Check for updated R files
+
+jobs:
+  updated-files:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ github.token }}
+    outputs:
+      any_changed: ${{ steps.changed-files.outputs.any_changed }}
+      all_modified_files: ${{ steps.changed-files.outputs.all_modified_files }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ inputs.fetch-depth }}
+
+      - name: Get all changed R package files
+        id: changed-files
+        uses: tj-actions/changed-files@v42
+        with:
+          base_sha: ${{ inputs.base_sha }}
+          # Avoid using single or double quotes for multiline patterns
+          files: ${{ inputs.files }}

--- a/.github/workflows/check-updated-files.yml
+++ b/.github/workflows/check-updated-files.yml
@@ -13,7 +13,7 @@ on:
         type: string
       base_sha:
         description: 'Base SHA to use for comparison'
-        required: true
+        required: false
         type: string
         default: |
           ${{


### PR DESCRIPTION
Closes #22 

Add an action to compare versions listed in DESCRIPTION, and fail if the version number in the branch is not greater than the version in the base (usually `main`)

Note that this only runs for `pull_request` events.