### PR TITLE
Feat/35 check docs up to date

### DIFF
--- a/.github/workflows/R-check-docs.yml
+++ b/.github/workflows/R-check-docs.yml
@@ -29,15 +29,13 @@ jobs:
       - name: Check for changed files
         run: |
           git add --all
-          changes=$(git diff-index HEAD --name-only)
+          changes=$(git diff-index HEAD --name-only -- man/ NAMESPACE DESCRIPTION)
           if [ -n "$changes" ]; then
             echo "Changes found after documenting."
             echo "$changes"
-            echo "\n Please update documentation."
+            echo "Please update documentation."
             exit 1
           else
             echo "No changes found after documenting."
             exit 0
           fi
-
-

--- a/.github/workflows/R-check-docs.yml
+++ b/.github/workflows/R-check-docs.yml
@@ -1,0 +1,43 @@
+---
+on:
+  workflow_call:
+
+name: "Documentation check"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::roxygen2
+          needs: roxygen2
+
+      - name: Document
+        run: roxygen2::roxygenise()
+        shell: Rscript {0}
+
+      - name: Check for changed files
+        run: |
+          git add --all
+          changes=$(git diff-index HEAD --name-only)
+          if [ -n "$changes" ]; then
+            echo "Changes found after documenting."
+            echo "$changes"
+            echo "\n Please update documentation."
+            exit 1
+          else
+            echo "No changes found after documenting."
+            exit 0
+          fi
+
+

--- a/.github/workflows/R-check-docs.yml
+++ b/.github/workflows/R-check-docs.yml
@@ -32,7 +32,7 @@ jobs:
           changes=$(git diff-index HEAD --name-only -- man/ NAMESPACE DESCRIPTION)
           if [ -n "$changes" ]; then
             echo "Changes found after documenting."
-            git diff
+            git --no-pager diff
             echo "$changes"
             echo "Please update documentation."
             exit 1

--- a/.github/workflows/R-check-docs.yml
+++ b/.github/workflows/R-check-docs.yml
@@ -5,7 +5,7 @@ on:
 name: "Documentation check"
 
 jobs:
-  lint:
+  docs-check:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ github.token }}

--- a/.github/workflows/R-check-docs.yml
+++ b/.github/workflows/R-check-docs.yml
@@ -32,6 +32,7 @@ jobs:
           changes=$(git diff-index HEAD --name-only -- man/ NAMESPACE DESCRIPTION)
           if [ -n "$changes" ]; then
             echo "Changes found after documenting."
+            git diff
             echo "$changes"
             echo "Please update documentation."
             exit 1

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: true
         type: boolean
+      do-docs-check:
+        description: 'Flag to check documentation is up to date'
+        required: false
+        default: true
+        type: boolean
       r-cmd-check-error-on:
         description: 'Level of R CMD CHECK issue to fail check'
         required: false
@@ -40,3 +45,8 @@ jobs:
     uses: ./.github/workflows/R-CMD-check.yml
     with:
       error-on: ${{ inputs.r-cmd-check-error-on }}
+
+  docs-check:
+    if: ${{ inputs.do-docs-check }}
+    uses: ./.github/workflows/R-check-docs.yml
+


### PR DESCRIPTION
Adds action to detect if rendered documentation is out of date

The most finicky part that I haven't sorted on this is if local `roxygen2` version is out of date, then `DESCRIPTION` will keep showing up as a changed file when `roxygenize` runs and updates its version in that file. One option would be to not check for changes in DESCRIPTION, or have that as a sign that it's time to update. ¯\_(ツ)_/¯

Failing Example: https://github.com/RMI-PACTA/pacta.workflow.utils/actions/runs/8253785326/job/22576447661#step:6:29
Passing Example: https://github.com/RMI-PACTA/pacta.workflow.utils/actions/runs/8253848573/job/22576646518#step:6:25