### PR TITLE
Fix JSON (add comma in array)

### DIFF
--- a/.github/workflows/docker-build-multiarch.yml
+++ b/.github/workflows/docker-build-multiarch.yml
@@ -26,7 +26,7 @@ on:
         type: string
         default: |
           [
-            "linux/amd64"
+            "linux/amd64",
             "linux/arm64"
           ]
     outputs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ on:
         type: string
         default: |
           [
-            "linux/amd64"
+            "linux/amd64",
             "linux/arm64"
           ]
       do-lint:


### PR DESCRIPTION
Add comma in JSON array, to make it valid

will fix https://github.com/RMI-PACTA/workflow.factset/issues/69