### PR TITLE
feat: update default ADO team path in gh-to-ado action

### DIFF
--- a/.github/workflows/issues-gh-to-ado.yml
+++ b/.github/workflows/issues-gh-to-ado.yml
@@ -4,7 +4,7 @@ on:
       ado_area_path:
         description: "ADO area path where ADO tickets are created."
         required: true
-        default: "2DegreesInvesting\\Test Team 1"
+        default: "2DegreesInvesting\\GitHub Issues"
         type: string
     secrets:
       ADO_TOKEN:

--- a/examples/issues.yml
+++ b/examples/issues.yml
@@ -21,6 +21,6 @@ jobs:
     name: Run issues workflows
     uses: RMI-PACTA/actions/.github/workflows/issues.yml@main
     with:
-      ado_area_path: "2DegreesInvesting\\Test Team 1"
+      ado_area_path: "2DegreesInvesting\\GitHub Issues"
     secrets:
       ADO_TOKEN: ${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
We now have an ADO scrum team called "GitHub Issues": https://dev.azure.com/RMI-PACTA/2DegreesInvesting/_backlogs/backlog/GitHub%20Issues/Backlog%20items

This is where we will house all ADO tickets that get sent from GH.

I think it makes sense to set this as the default space, to remove burden required by maintainers to keep this up to date.