### PR TITLE
Update default input for platform

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,13 +19,13 @@ on:
         required: false
         type: string
         default: |
-        ${{
-          github.event_name == 'pull_request' && ["linux/amd64"] ||
-          [
-            "linux/amd64",
-            "linux/arm64"
-          ]
-        }}
+          ${{
+            github.event_name == 'pull_request' && ["linux/amd64"] ||
+            [
+              "linux/amd64",
+              "linux/arm64"
+            ]
+          }}
       do-lint:
         description: 'Flag to lint Dockerfile'
         required: false
@@ -76,4 +76,3 @@ jobs:
     needs: [build-docker-image]
     with:
       header: "Docker build status"
-

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ on:
         type: string
         default: |
           ${{
-            github.event_name == 'pull_request' && ["linux/amd64"] ||
+            github.event_name == 'pull_request' && '["linux/amd64"]' ||
             [
               "linux/amd64",
               "linux/arm64"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,10 +21,10 @@ on:
         default: |
           ${{
             github.event_name == 'pull_request' && '["linux/amd64"]' ||
-            [
+            '[
               "linux/amd64",
               "linux/arm64"
-            ]
+            ]'
           }}
       do-lint:
         description: 'Flag to lint Dockerfile'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,10 +19,13 @@ on:
         required: false
         type: string
         default: |
+        ${{
+          github.event_name == 'pull_request' && ["linux/amd64"] ||
           [
             "linux/amd64",
             "linux/arm64"
           ]
+        }}
       do-lint:
         description: 'Flag to lint Dockerfile'
         required: false


### PR DESCRIPTION
Update so that default build platform for PRs is `amd64`, and does not include the `arm64` (which typically has much longer builds).

Closes #83 