### PR TITLE
Add ref.name and version to Docker labels

### DIFF
--- a/.github/workflows/docker-build-multiarch.yml
+++ b/.github/workflows/docker-build-multiarch.yml
@@ -116,8 +116,8 @@ jobs:
           echo "org.opencontainers.image.version=$VERSION_STRING"
           echo 'dockerfile-labels<<EOF' >> $GITHUB_OUTPUT
           echo "$DOCKERFILE_LABELS" >> $GITHUB_OUTPUT
-          echo "org.opencontainers.image.ref.name=$REF_NAME"
-          echo "org.opencontainers.image.version=$VERSION_STRING"
+          echo "org.opencontainers.image.ref.name=$REF_NAME" >> "$GITHUB_OUTPUT"
+          echo "org.opencontainers.image.version=$VERSION_STRING" >> "$GITHUB_OUTPUT"
           echo 'EOF' >> $GITHUB_OUTPUT
 
       # Setup docker metadata, including tags and labels (and annotations)

--- a/.github/workflows/docker-build-multiarch.yml
+++ b/.github/workflows/docker-build-multiarch.yml
@@ -110,14 +110,13 @@ jobs:
           VERSION_STRING: ${{ steps.identify-version.outputs.version-string }}
           REF_NAME: ${{ steps.identify-version.outputs.ref-name }}
         run: |
-          DOCKERFILE_LABELS="$(grep "^LABEL" Dockerfile | sed 's/^LABEL[[:space:]]*//')"
+          grep "^LABEL" Dockerfile | sed 's/^LABEL[[:space:]]*//' > dockerlabels.txt
+          echo "org.opencontainers.image.ref.name=$REF_NAME" >> dockerlabels.txt
+          echo "org.opencontainers.image.version=$VERSION_STRING" >> dockerlabels.txt
+          DOCKERFILE_LABELS="$(cat dockerlabels.txt)"
           echo "$DOCKERFILE_LABELS"
-          echo "org.opencontainers.image.ref.name=$REF_NAME"
-          echo "org.opencontainers.image.version=$VERSION_STRING"
           echo 'dockerfile-labels<<EOF' >> $GITHUB_OUTPUT
           echo "$DOCKERFILE_LABELS" >> $GITHUB_OUTPUT
-          echo "org.opencontainers.image.ref.name=$REF_NAME" >> "$GITHUB_OUTPUT"
-          echo "org.opencontainers.image.version=$VERSION_STRING" >> "$GITHUB_OUTPUT"
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Preview LABELS

--- a/.github/workflows/docker-build-multiarch.yml
+++ b/.github/workflows/docker-build-multiarch.yml
@@ -106,12 +106,14 @@ jobs:
       # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
       - name: Identify LABELs in dockerfile
         id: custom-labels
+        env:
+          VERSION_STRING: ${{ steps.identify-version.outputs.version-string }}
+          REF_NAME: ${{ steps.identify-version.outputs.ref-name }}
         run: |
           DOCKERFILE_LABELS="$(grep "^LABEL" Dockerfile | sed 's/^LABEL[[:space:]]*//')"
+          DOCKERFILE_LABELS="${DOCKERFILE_LABELS}\norg.opencontainers.image.ref.name=$REF_NAME"
+          DOCKERFILE_LABELS="${DOCKERFILE_LABELS}\norg.opencontainers.image.version=$VERSION_STRING"
           echo "$DOCKERFILE_LABELS"
-          echo "DOCKERFILE_LABELS<<EOF" >> $GITHUB_ENV
-          echo "$DOCKERFILE_LABELS" >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
           echo 'dockerfile-labels<<EOF' >> $GITHUB_OUTPUT
           echo "$DOCKERFILE_LABELS" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
@@ -120,19 +122,12 @@ jobs:
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
-        env:
-          VERSION_STRING: ${{ steps.identify-version.outputs.version-string }}
-          REF_NAME: ${{ steps.identify-version.outputs.ref-name }}
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           annotations:
-            ${{ env.DOCKERFILE_LABELS }}
-            org.opencontainers.image.ref.name="$REF_NAME"
-            org.opencontainers.image.version="$VERSION_STRING"
+            ${{ steps.custom-labels.outputs.DOCKERFILE_LABELS }}
           labels:
-            ${{ env.DOCKERFILE_LABELS }}
-            org.opencontainers.image.ref.name="$REF_NAME"
-            org.opencontainers.image.version="$VERSION_STRING"
+            ${{ steps.custom-labels.outputs.DOCKERFILE_LABELS }}
 
       # set up our build environment
       - name: Set up QEMU

--- a/.github/workflows/docker-build-multiarch.yml
+++ b/.github/workflows/docker-build-multiarch.yml
@@ -111,11 +111,13 @@ jobs:
           REF_NAME: ${{ steps.identify-version.outputs.ref-name }}
         run: |
           DOCKERFILE_LABELS="$(grep "^LABEL" Dockerfile | sed 's/^LABEL[[:space:]]*//')"
-          DOCKERFILE_LABELS="${DOCKERFILE_LABELS}\norg.opencontainers.image.ref.name=$REF_NAME"
-          DOCKERFILE_LABELS="${DOCKERFILE_LABELS}\norg.opencontainers.image.version=$VERSION_STRING"
           echo "$DOCKERFILE_LABELS"
+          echo "org.opencontainers.image.ref.name=$REF_NAME"
+          echo "org.opencontainers.image.version=$VERSION_STRING"
           echo 'dockerfile-labels<<EOF' >> $GITHUB_OUTPUT
           echo "$DOCKERFILE_LABELS" >> $GITHUB_OUTPUT
+          echo "org.opencontainers.image.ref.name=$REF_NAME"
+          echo "org.opencontainers.image.version=$VERSION_STRING"
           echo 'EOF' >> $GITHUB_OUTPUT
 
       # Setup docker metadata, including tags and labels (and annotations)

--- a/.github/workflows/docker-build-multiarch.yml
+++ b/.github/workflows/docker-build-multiarch.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Preview LABELS
         env:
-          DOCKERFILE_LABELS: ${{ steps.custom-labels.outputs.DOCKERFILE_LABELS }}
+          DOCKERFILE_LABELS: ${{ steps.custom-labels.outputs.dockerfile-labels }}
         run: echo "$DOCKERFILE_LABELS"
 
       # Setup docker metadata, including tags and labels (and annotations)
@@ -131,9 +131,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           annotations:
-            ${{ steps.custom-labels.outputs.DOCKERFILE_LABELS }}
+            ${{ steps.custom-labels.outputs.dockerfile-labels }}
           labels:
-            ${{ steps.custom-labels.outputs.DOCKERFILE_LABELS }}
+            ${{ steps.custom-labels.outputs.dockerfile-labels }}
 
       # set up our build environment
       - name: Set up QEMU

--- a/.github/workflows/docker-build-multiarch.yml
+++ b/.github/workflows/docker-build-multiarch.yml
@@ -78,6 +78,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Identify Version
+        id: identify-version
+        env:
+          GH_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          IMAGE_NAME: ${{ inputs.image-name }}
+        run: |
+          if [ -f "DESCRIPTION" ]; then
+            echo "Finding Version String"
+            VERSION_STRING="$(
+              grep "^Version:\s\+" "DESCRIPTION" |
+                sed 's/^Version:[ \t]*//'
+            )"
+          fi
+          VERSION_STRING="${VERSION_STRING:-$GH_SHA}"
+          echo "version-string=$VERSION_STRING"
+          echo "version-string=$VERSION_STRING" >> "$GITHUB_OUTPUT"
+          REF_NAME="${IMAGE_NAME}:${VERSION_STRING}"
+          echo "ref-name=$REF_NAME"
+          echo "ref-name=$REF_NAME" >> "$GITHUB_OUTPUT"
+
       # Extract the LABEL lines in the dockerfile, and extract their contents.
       # write to both env and as an output to be used in merge job. This will
       # let us use the LABELs defined there as the labels for our image. Note
@@ -100,12 +120,19 @@ jobs:
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
+        env:
+          VERSION_STRING: ${{ steps.identify-version.outputs.version-string }}
+          REF_NAME: ${{ steps.identify-version.outputs.ref-name }}
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           annotations:
             ${{ env.DOCKERFILE_LABELS }}
+            org.opencontainers.image.ref.name="$REF_NAME"
+            org.opencontainers.image.version="$VERSION_STRING"
           labels:
             ${{ env.DOCKERFILE_LABELS }}
+            org.opencontainers.image.ref.name="$REF_NAME"
+            org.opencontainers.image.version="$VERSION_STRING"
 
       # set up our build environment
       - name: Set up QEMU

--- a/.github/workflows/docker-build-multiarch.yml
+++ b/.github/workflows/docker-build-multiarch.yml
@@ -120,6 +120,11 @@ jobs:
           echo "org.opencontainers.image.version=$VERSION_STRING" >> "$GITHUB_OUTPUT"
           echo 'EOF' >> $GITHUB_OUTPUT
 
+      - name: Preview LABELS
+        env:
+          DOCKERFILE_LABELS: ${{ steps.custom-labels.outputs.DOCKERFILE_LABELS }}
+        run: echo "$DOCKERFILE_LABELS"
+
       # Setup docker metadata, including tags and labels (and annotations)
       - name: Docker meta
         id: meta


### PR DESCRIPTION
Adds handling to procedurally add the  `org.opencontainers.image.ref.name` and `org.opencontainers.image.version` LABELs to docker images built with the `build-multiarch` workflow.

See it in action: https://github.com/RMI-PACTA/workflow.pacta/actions/runs/9192927847/job/25282786031#step:7:61