### PR TITLE
Add check that dependencies point to default

### DIFF
--- a/.github/workflows/R-dep-main-check.yml
+++ b/.github/workflows/R-dep-main-check.yml
@@ -3,10 +3,10 @@
 on:
   workflow_call:
 
-name: lint
+name: deps-main
 
 jobs:
-  lint:
+  deps-main:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ github.token }}

--- a/.github/workflows/R-dep-main-check.yml
+++ b/.github/workflows/R-dep-main-check.yml
@@ -1,0 +1,33 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  workflow_call:
+
+name: lint
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pak, local::.
+
+      - name: Check R dependencies
+        run: |
+          deps <- pak::local_deps()
+          refs <- deps[["ref"]]
+          non_default <- refs[grepl(x = refs, pattern = "@", fixed = TRUE)]
+          if (length(non_default)) {
+            print(non_default)
+            stop("Non default references found in dependencies.")
+          }
+        shell: Rscript {0}

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -28,6 +28,11 @@ on:
         required: false
         default: true
         type: boolean
+      do-deps-main-check:
+        description: 'Flag to check dependencies point to default'
+        required: false
+        default: true
+        type: boolean
       r-cmd-check-error-on:
         description: 'Level of R CMD CHECK issue to fail check'
         required: false
@@ -94,3 +99,7 @@ jobs:
   docs-check:
     if: ${{ inputs.do-docs-check }}
     uses: ./.github/workflows/R-check-docs.yml
+
+  deps-main-check:
+    if: ${{ inputs.do-deps-main-check }}
+    uses: ./.github/workflows/R-dep-main-check.yml


### PR DESCRIPTION
Adds a check that dependencies point to the default source (`main` for GH repos, but really checking for anything with an `@` in the `pak` reference. 

See [`pak` documentation](https://pak.r-lib.org/reference/pak_package_sources.html) for more information about specifying with `@` for versions.

Note that this isn't a perfect solution. There's a lot of edge cases where this may throw a false positive (specifying `foo@main` for example), but for our current development paradigm, this is a good first pass that we can improve on if we need to.

Closes #86 

See it in action! (ignore the other actions failing 😄 )

Failing check: https://github.com/RMI-PACTA/workflow.pacta/actions/runs/9267899366/job/25495339371

Passing Check: https://github.com/RMI-PACTA/workflow.pacta/actions/runs/9267913996/job/25495388263