### PR TITLE
Add remotes input

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -84,6 +84,7 @@ jobs:
             options(repos = r)
           })
           EOF
+          Rscript -e 'getOption("repos")'
         shell: bash
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -66,4 +66,4 @@ jobs:
         with:
           upload-snapshots: true
           error-on: ${{ inputs.error-on }}
-          snapshot-artifact-name: ${{ format('{0}-{1}-r{2}-{3}-testthat-snapshots-{4}-{5}', runner.os, runner.arch, matrix.config.r, matrix.config.id, github.run_id, github.run_attempt }}
+          snapshot-artifact-name: ${{ format('{0}-{1}-r{2}-{3}-testthat-snapshots-{4}-{5}', runner.os, runner.arch, matrix.config.r, matrix.config.id, github.run_id, github.run_attempt) }}

--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -30,6 +30,11 @@ on:
         required: false
         default: ''
         type: string
+      prepend-repositories:
+        description: 'One or more extra CRAN-like repositories to have priority over the default repos global option'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   R-CMD-check:
@@ -56,6 +61,19 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
           extra-repositories: ${{ inputs.extra-repositories }}
+
+      - name: Prepend repositories
+        if: ${{ inputs.prepend-repositories }}
+        env:
+          PREPEND_REPOS: ${{ inputs.prepend-repositories }}
+        run: |
+          cat <<EOF >>   "~/.Rprofile"
+          local({
+            prepend <- unlist(strsplit(x = Sys.getenv("PREPEND_REPOS"), split = ",", fixed = TRUE))
+            r <- append(getOption("repos"), prepend, after = 0L)
+            options(repos = r)
+          })
+          EOF
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -25,6 +25,11 @@ on:
             {"os": "ubuntu-latest", "r": "oldrel-3"},
             {"os": "ubuntu-latest", "r": "oldrel-4"}
           ]
+      extra-repositories:
+        description: 'One or more extra CRAN-like repositories to include in the repos global option'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   R-CMD-check:
@@ -50,6 +55,7 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
+          extra-repositories: ${{ inputs.extra-repositories }}
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -84,7 +84,7 @@ jobs:
             options(repos = r)
           })
           EOF
-          Rscript -e 'getOption("repos")'
+          Rscript -e 'pak::repo_get()'
         shell: bash
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -30,7 +30,7 @@ on:
         required: false
         default: ''
         type: string
-      prepend-repositories:
+      PRepend-repositories:
         description: 'One or more extra CRAN-like repositories to have priority over the default repos global option'
         required: false
         default: ''
@@ -67,7 +67,7 @@ jobs:
         env:
           PREPEND_REPOS: ${{ inputs.prepend-repositories }}
         run: |
-          cat <<EOF >>   "~/.Rprofile"
+          cat <<EOF >> ~/.Rprofile
           local({
             prepend <- unlist(strsplit(x = Sys.getenv("PREPEND_REPOS"), split = ",", fixed = TRUE))
             r <- append(getOption("repos"), prepend, after = 0L)

--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -79,6 +79,7 @@ jobs:
             options(repos = r)
           })
           EOF
+        shell: bash
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -66,3 +66,4 @@ jobs:
         with:
           upload-snapshots: true
           error-on: ${{ inputs.error-on }}
+          snapshot-artifact-name: ${{ format('{0}-{1}-r{2}-{3}-testthat-snapshots-{4}-{5}', runner.os, runner.arch, matrix.config.r, matrix.config.id, github.run_id, github.run_attempt }}

--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -40,6 +40,11 @@ on:
         required: false
         default: 'FALSE'
         type: string
+      cache-version:
+        description: 'passed to setup-r-dependencies cache-version'
+        required: false
+        default: 1
+        type: string
 
 jobs:
   R-CMD-check:
@@ -86,6 +91,7 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
           upgrade: ${{ inputs.upgrade-packages }}
+          cache-version: ${{ inputs.cache-version }}
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -30,10 +30,15 @@ on:
         required: false
         default: ''
         type: string
-      PRepend-repositories:
+      prepend-repositories:
         description: 'One or more extra CRAN-like repositories to have priority over the default repos global option'
         required: false
         default: ''
+        type: string
+      upgrade-packages:
+        description: 'passed to setup-r-dependencies upgrade'
+        required: false
+        default: 'FALSE'
         type: string
 
 jobs:
@@ -79,6 +84,7 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           needs: check
+          upgrade: ${{ inputs.upgrade-packages }}
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -30,11 +30,6 @@ on:
         required: false
         default: ''
         type: string
-      prepend-repositories:
-        description: 'One or more extra CRAN-like repositories to have priority over the default repos global option'
-        required: false
-        default: ''
-        type: string
       upgrade-packages:
         description: 'passed to setup-r-dependencies upgrade'
         required: false
@@ -42,6 +37,11 @@ on:
         type: string
       cache-version:
         description: 'passed to setup-r-dependencies cache-version'
+        required: false
+        default: 1
+        type: string
+      remotes:
+        description: 'entires to add as a Remotes field in DESCRIPTION'
         required: false
         default: 1
         type: string
@@ -72,19 +72,16 @@ jobs:
           use-public-rspm: true
           extra-repositories: ${{ inputs.extra-repositories }}
 
-      - name: Prepend repositories
-        if: ${{ inputs.prepend-repositories }}
+      - name: Add Remotes
+        if: ${{ inputs.remotes }}
         env:
-          PREPEND_REPOS: ${{ inputs.prepend-repositories }}
+          REMOTES: ${{ inputs.remotes }}
         run: |
-          cat <<EOF >> ~/.Rprofile
-          local({
-            prepend <- unlist(strsplit(x = Sys.getenv("PREPEND_REPOS"), split = ",", fixed = TRUE))
-            r <- append(getOption("repos"), prepend, after = 0L)
-            options(repos = r)
-          })
+          cat <<EOF >> DESCRIPTION
+          Remotes:
+            $REMOTES
           EOF
-          Rscript -e 'pak::repo_get()'
+          cat DESCRIPTION
         shell: bash
 
       - uses: r-lib/actions/setup-r-dependencies@v2


### PR DESCRIPTION
Add input to allow additional remotes for installing packages from.

Intended use case is to all for installing dev versions of packages from github

See it in action: https://github.com/RMI-PACTA/r2dii.match/pull/480