### PR TITLE
Use cache name to also separate artifacts

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -95,4 +95,4 @@ jobs:
         with:
           upload-snapshots: true
           error-on: ${{ inputs.error-on }}
-          snapshot-artifact-name: ${{ format('{0}-{1}-r{2}-{3}-testthat-snapshots-{4}-{5}', runner.os, runner.arch, matrix.config.r, matrix.config.id, github.run_id, github.run_attempt) }}
+          snapshot-artifact-name: ${{ format('{0}-{1}-r{2}-{3}-testthat-snapshots-{4}', runner.os, runner.arch, matrix.config.r, matrix.config.id, inputs.cache-version) }}


### PR DESCRIPTION
Testing here https://github.com/RMI-PACTA/r2dii.match/pull/486

(I've finally updated both the normal and dev checks to use the same branch at the same time. Genius.)