### PR TITLE
Ci/95 r rev dep check

### DIFF
--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -35,8 +35,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: ${{ matrix.config.r }}
-          http-user-agent: ${{ matrix.config.http-user-agent }}
+          r-version: "devel"
+          http-user-agent: "release"
           use-public-rspm: true
 
       - name: Download Reverse Dependency

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -82,12 +82,13 @@ jobs:
         env:
           REVDEP_FILE: ${{ steps.download-revdep.outputs.revdep-file }}
         run: |
-          ls
           BEFORE=$(find . -maxdepth 1 -type d)
+          echo "BEFORE=$BEFORE"
           tar -x -f "$REVDEP_FILE"
-          ls
           AFTER=$(find . -maxdepth 1 -type d)
+          echo "AFTER=$AFTER"
           NEW_DIRS=$(comm -13 <(echo "$before") <(echo "$after"))
+          echo "NEW_DIRS=$NEW_DIRS"
           echo "revdep-dir=$NEW_DIRS"
           echo "revdep-dir=$NEW_DIRS" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -84,6 +84,7 @@ jobs:
           )
 
       - name: Unpack revdep
+        id: unpack-revdep
         env:
           REVDEP_FILE: ${{ steps.download-revdep.outputs.revdep-file }}
           REVDEP_TYPE: ${{ steps.download-revdep.outputs.revdep-type }}
@@ -121,7 +122,7 @@ jobs:
           needs: check
           upgrade: 'TRUE'
           dependencies: '"all"'
-          working-directory: ${{ steps.download-revdep.outputs.revdep-dir }}
+          working-directory: ${{ steps.unpack-revdep.outputs.revdep-dir }}
           cache-version: ${{ matrix.config.pkg }}
 
       - name: Install local HEAD
@@ -136,4 +137,4 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         name: Check reverse dependency
         with:
-          working-directory: ${{ steps.download-revdep.outputs.revdep-dir }}
+          working-directory: ${{ steps.unpack-revdep.outputs.revdep-dir }}

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -77,10 +77,16 @@ jobs:
             file = Sys.getenv("GITHUB_OUTPUT"),
             append = TRUE
           )
+          cat(
+            paste0("revdep-type=", dl[["type"]][[1L]], "\n"),
+            file = Sys.getenv("GITHUB_OUTPUT"),
+            append = TRUE
+          )
 
       - name: Unpack revdep
         env:
           REVDEP_FILE: ${{ steps.download-revdep.outputs.revdep-file }}
+          REVDEP_TYPE: ${{ steps.download-revdep.outputs.revdep-type }}
         run: |
           if [ "$(expr "$string" : '.*-t$')" -ne 0 ]; then
             newname="(echo $REVDEP_FILE | sed 's/-t$//')"
@@ -92,7 +98,7 @@ jobs:
           find . -maxdepth 1 -mindepth 1 -type d | sed 's|^\./||' | sort > .dirs_before
           echo "BEFORE"
           cat .dirs_before
-          tar -x -f "$REVDEP_FILE"
+          unzip "$REVDEP_FILE"
           find . -maxdepth 1 -mindepth 1 -type d | sed 's|^\./||' | sort > .dirs_after
           echo "AFTER"
           cat .dirs_after

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -98,6 +98,7 @@ jobs:
           )
 
       - uses: r-lib/actions/check-r-package@v2
+        name: Check reverse dependency
         with:
           working-directory: ${{ steps.download-revdep.outputs.revdep-pkg }}
           upload-snapshots: true

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -39,7 +39,7 @@ jobs:
           http-user-agent: release
           use-public-rspm: true
 
-      - name: Download Reverse Dependency
+      - name: Download and unpack Reverse Dependency
         id: download-revdep
         env:
           REVDEP: ${{ matrix.config.pkg }}

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -59,24 +59,23 @@ jobs:
             dest_dir = "revdep-source",
             dependencies = FALSE
           )
-          print(dl[, c("fulltarget", "package")])
-          cat(
-            paste0("revdep-file=", dl[["fulltarget"]][[1L]], "\n"),
-            file = Sys.getenv("GITHUB_OUTPUT"),
-            append = TRUE
+          print(dl[, "package"])
+          if ( file.exists(dl[["fulltarget"]][[1L]]) ) {
+            target_tar <- dl[["fulltarget"]][[1L]]
+          } else if ( file.exists(dl[["fulltarget_tree"]][[1L]]) ) {
+            target_tar <- dl[["fulltarget_tree"]][[1L]]
+          } else {
+            stop("No valid downloads found.")
+          }
+          untar(
+            tarfile = taget_tar,
+            exdir = dl[["package"]][[1L]]
           )
           cat(
             paste0("revdep-pkg=", dl[["package"]][[1L]], "\n"),
             file = Sys.getenv("GITHUB_OUTPUT"),
             append = TRUE
           )
-
-      - name: Unpack revdep
-        env:
-          DESTINATION: revdep
-          REVDEP_FILE: ${{ steps.download-revdep.outputs.revdep-file }}
-        run: |
-          tar -xv -f "$REVDEP_FILE"
 
       - name: Install revdep dependencies
         uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -1,0 +1,105 @@
+---
+name: R Reverse Dependency Check
+
+on:
+  workflow_call:
+    inputs:
+      focus-package:
+        description: 'Package for which reverse dependency should be checked'
+        required: true
+        default: '"note"'
+        type: string
+      upgrade-packages:
+        description: 'passed to setup-r-dependencies upgrade'
+        required: false
+        default: 'TRUE'
+        type: string
+      revdeps:
+        description: 'Reverse dependency to check. Accepts {pak} specifications as JSON string'
+        required: false
+        type: string
+        default: |
+          [
+            {"pkg": "r2dii.match"},
+            {"pkg": "RMI-PACTA/r2dii.match"},
+          ]
+
+jobs:
+  R-revdep-check:
+    runs-on: ubuntu-latest
+    name: revdep ${{ matrix.config.pkg }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJSON(inputs.revdeps) }}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: "yes"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: "local_package"
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+          extra-repositories: ${{ inputs.extra-repositories }}
+
+      - name: Download Reverse Dependency
+        id: download-revdep
+        env:
+          REVDEP: ${{ matrix.config.pkg }}
+        shell: Rscript {0}
+        run: |
+          dl <- pak::pkg_download(
+            pkg = Sys.getenv("REVDEP"),
+            dest_dir = "revdep-source",
+            dependencies = FALSE
+          )
+          cat(
+            paste0("revdep-file=", dl[["fulltarget"]][[1L]])
+            file = Sys.getenv("GITHUB_OUTPUT")
+          )
+          cat(
+            paste0("revdep-pkg=", dl[["package"]][[1L]])
+            file = Sys.getenv("GITHUB_OUTPUT")
+          )
+
+      - name: Unpack revdep
+        env:
+          DESTINATION: revdep
+          REVDEP_FILE: ${{ steps.download-revdep.outputs.revdep-file }}
+        run: |
+          tar -xv -f "$REVDEP_FILE"
+
+      - name: Install revdep dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+          upgrade: 'TRUE'
+          dependencies: '"all"'
+          working-directory: ${{ steps.download-revdep.outputs.revdep-pkg }}
+          cache-version: ${{ matrix.config.pkg }}
+
+      - name: Install local HEAD
+        id: install-package
+        env:
+        shell: Rscript {0}
+        run: |
+          dl <- pak::local_install(
+            root = "local_package",
+            dependencies = TRUE
+          )
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          working-directory: ${{ steps.download-revdep.outputs.revdep-pkg }}
+          upload-snapshots: true
+          error-on: ${{ inputs.error-on }}
+          snapshot-artifact-name: ${{ format('{0}-{1}-r{2}-{3}-testthat-snapshots-{4}', runner.os, runner.arch, matrix.config.r, matrix.config.id, inputs.cache-version) }}

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -39,7 +39,7 @@ jobs:
           http-user-agent: release
           use-public-rspm: true
 
-      - name: Download and unpack Reverse Dependency
+      - name: Download Reverse Dependency
         id: download-revdep
         env:
           REVDEP: ${{ matrix.config.pkg }}
@@ -71,6 +71,7 @@ jobs:
             paste0("revdep-file=", target_tar, "\n"),
             file = Sys.getenv("GITHUB_OUTPUT"),
             append = TRUE
+          )
           cat(
             paste0("revdep-pkg=", dl[["package"]][[1L]], "\n"),
             file = Sys.getenv("GITHUB_OUTPUT"),

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -98,10 +98,17 @@ jobs:
           find . -maxdepth 1 -mindepth 1 -type d | sed 's|^\./||' | sort > .dirs_before
           echo "BEFORE"
           cat .dirs_before
-          unzip "$REVDEP_FILE"
+
+          if [ "$REVDEP_TYPE" = "github" ]; then
+            unzip "$REVDEP_FILE"
+          else
+            tar -x -f "$REVDEP_FILE"
+          fi
+
           find . -maxdepth 1 -mindepth 1 -type d | sed 's|^\./||' | sort > .dirs_after
           echo "AFTER"
           cat .dirs_after
+
           NEW_DIRS=$(comm -13 .dirs_before .dirs_after)
           echo "NEW_DIRS=$NEW_DIRS"
           echo "revdep-dir=$NEW_DIRS"

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -59,13 +59,16 @@ jobs:
             dest_dir = "revdep-source",
             dependencies = FALSE
           )
+          print(dl[, c("fulltarget", "package")])
           cat(
-            paste0("revdep-file=", dl[["fulltarget"]][[1L]]),
-            file = Sys.getenv("GITHUB_OUTPUT")
+            paste0("revdep-file=", dl[["fulltarget"]][[1L]], "\n"),
+            file = Sys.getenv("GITHUB_OUTPUT"),
+            append = TRUE
           )
           cat(
-            paste0("revdep-pkg=", dl[["package"]][[1L]]),
-            file = Sys.getenv("GITHUB_OUTPUT")
+            paste0("revdep-pkg=", dl[["package"]][[1L]], "\n"),
+            file = Sys.getenv("GITHUB_OUTPUT"),
+            append = TRUE
           )
 
       - name: Unpack revdep

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -82,12 +82,14 @@ jobs:
         env:
           REVDEP_FILE: ${{ steps.download-revdep.outputs.revdep-file }}
         run: |
-          BEFORE=$(find . -maxdepth 1 -type d)
-          echo "BEFORE=$BEFORE"
+          find . -maxdepth 1 -type d > .dirs_before
+          echo "BEFORE"
+          cat .dirs_before
           tar -x -f "$REVDEP_FILE"
-          AFTER=$(find . -maxdepth 1 -type d)
-          echo "AFTER=$AFTER"
-          NEW_DIRS=$(comm -13 <(echo "$BEFORE") <(echo "$AFTER"))
+          find . -maxdepth 1 -type d > .dirs_after
+          echo "AFTER"
+          cat .dirs_after
+          NEW_DIRS=$(comm -13 .dirs_before .dirs_after)
           echo "NEW_DIRS=$NEW_DIRS"
           echo "revdep-dir=$NEW_DIRS"
           echo "revdep-dir=$NEW_DIRS" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -77,6 +77,9 @@ jobs:
             append = TRUE
           )
 
+      - name: inpsect
+        run: ls -laR
+
       - name: Install revdep dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -82,6 +82,13 @@ jobs:
         env:
           REVDEP_FILE: ${{ steps.download-revdep.outputs.revdep-file }}
         run: |
+          if [ "$(expr "$string" : '.*-t$')" -ne 0 ]; then
+            newname="(echo $REVDEP_FILE | sed 's/-t$//')"
+            echo "Copying $REVDEP_FILE to $newname"
+            cp "$REVDEP_FILE" "$newname"
+            REVDEP_FILE="$newname"
+          fi
+
           find . -maxdepth 1 -type d > .dirs_before
           echo "BEFORE"
           cat .dirs_before

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -35,8 +35,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: "devel"
-          http-user-agent: "release"
+          r-version: 'devel'
+          http-user-agent: 'release'
           use-public-rspm: true
 
       - name: Download Reverse Dependency

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -89,11 +89,11 @@ jobs:
             REVDEP_FILE="$newname"
           fi
 
-          find . -maxdepth 1 -type d > .dirs_before
+          find . -maxdepth 1 -type d | sort > .dirs_before
           echo "BEFORE"
           cat .dirs_before
           tar -x -f "$REVDEP_FILE"
-          find . -maxdepth 1 -type d > .dirs_after
+          find . -maxdepth 1 -type d | sort > .dirs_after
           echo "AFTER"
           cat .dirs_after
           NEW_DIRS=$(comm -13 .dirs_before .dirs_after)

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -60,11 +60,11 @@ jobs:
             dependencies = FALSE
           )
           cat(
-            paste0("revdep-file=", dl[["fulltarget"]][[1L]])
+            paste0("revdep-file=", dl[["fulltarget"]][[1L]]),
             file = Sys.getenv("GITHUB_OUTPUT")
           )
           cat(
-            paste0("revdep-pkg=", dl[["package"]][[1L]])
+            paste0("revdep-pkg=", dl[["package"]][[1L]]),
             file = Sys.getenv("GITHUB_OUTPUT")
           )
 

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -89,11 +89,11 @@ jobs:
             REVDEP_FILE="$newname"
           fi
 
-          find . -maxdepth 1 -type d | sort > .dirs_before
+          find . -maxdepth 1 -mindepth 1 -type d | sed 's|^\./||' | sort > .dirs_before
           echo "BEFORE"
           cat .dirs_before
           tar -x -f "$REVDEP_FILE"
-          find . -maxdepth 1 -type d | sort > .dirs_after
+          find . -maxdepth 1 -mindepth 1 -type d | sed 's|^\./||' | sort > .dirs_after
           echo "AFTER"
           cat .dirs_after
           NEW_DIRS=$(comm -13 .dirs_before .dirs_after)

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -45,6 +45,15 @@ jobs:
           REVDEP: ${{ matrix.config.pkg }}
         shell: Rscript {0}
         run: |
+          install.packages(
+            "pak",
+            repos = sprintf(
+              "https://r-lib.github.io/p/pak/stable/%s/%s/%s",
+              .Platform$pkgType,
+              R.Version()$os,
+              R.Version()$arch
+            )
+          )
           dl <- pak::pkg_download(
             pkg = Sys.getenv("REVDEP"),
             dest_dir = "revdep-source",

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -4,16 +4,6 @@ name: R Reverse Dependency Check
 on:
   workflow_call:
     inputs:
-      focus-package:
-        description: 'Package for which reverse dependency should be checked'
-        required: true
-        default: '"note"'
-        type: string
-      upgrade-packages:
-        description: 'passed to setup-r-dependencies upgrade'
-        required: false
-        default: 'TRUE'
-        type: string
       revdeps:
         description: 'Reverse dependency to check. Accepts {pak} specifications as JSON string'
         required: false
@@ -48,7 +38,6 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
-          extra-repositories: ${{ inputs.extra-repositories }}
 
       - name: Download Reverse Dependency
         id: download-revdep
@@ -101,6 +90,3 @@ jobs:
         name: Check reverse dependency
         with:
           working-directory: ${{ steps.download-revdep.outputs.revdep-pkg }}
-          upload-snapshots: true
-          error-on: ${{ inputs.error-on }}
-          snapshot-artifact-name: ${{ format('{0}-{1}-r{2}-{3}-testthat-snapshots-{4}', runner.os, runner.arch, matrix.config.r, matrix.config.id, inputs.cache-version) }}

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -80,11 +80,12 @@ jobs:
 
       - name: Unpack revdep
         env:
-          DESTINATION: ${{ steps.download-revdep.outputs.revdep-pkg }}
           REVDEP_FILE: ${{ steps.download-revdep.outputs.revdep-file }}
         run: |
+          ls
           BEFORE=$(find . -maxdepth 1 -type d)
           tar -x -f "$REVDEP_FILE"
+          ls
           AFTER=$(find . -maxdepth 1 -type d)
           NEW_DIRS=$(comm -13 <(echo "$before") <(echo "$after"))
           echo "revdep-dir=$NEW_DIRS"

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -67,18 +67,26 @@ jobs:
           } else {
             stop("No valid downloads found.")
           }
-          untar(
-            tarfile = target_tar,
-            exdir = dl[["package"]][[1L]]
-          )
+          cat(
+            paste0("revdep-file=", target_tar, "\n"),
+            file = Sys.getenv("GITHUB_OUTPUT"),
+            append = TRUE
           cat(
             paste0("revdep-pkg=", dl[["package"]][[1L]], "\n"),
             file = Sys.getenv("GITHUB_OUTPUT"),
             append = TRUE
           )
 
-      - name: inpsect
-        run: ls -laR
+      - name: Unpack revdep
+        env:
+          DESTINATION: ${{ steps.download-revdep.outputs.revdep-pkg }}
+          REVDEP_FILE: ${{ steps.download-revdep.outputs.revdep-file }}
+        run: |
+          BEFORE=$(find . -maxdepth 1 -type d)
+          tar -xv -f "$REVDEP_FILE"
+          AFTER=$(find . -maxdepth 1 -type d)
+          NEW_DIRS=$(comm -13 <(echo "$before") <(echo "$after"))
+          echo "revdep-dir=$NEW_DIRS" >> "$GITHUB_OUTPUT"
 
       - name: Install revdep dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
@@ -87,7 +95,7 @@ jobs:
           needs: check
           upgrade: 'TRUE'
           dependencies: '"all"'
-          working-directory: ${{ steps.download-revdep.outputs.revdep-pkg }}
+          working-directory: ${{ steps.download-revdep.outputs.revdep-dir }}
           cache-version: ${{ matrix.config.pkg }}
 
       - name: Install local HEAD
@@ -102,4 +110,4 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         name: Check reverse dependency
         with:
-          working-directory: ${{ steps.download-revdep.outputs.revdep-pkg }}
+          working-directory: ${{ steps.download-revdep.outputs.revdep-dir }}

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -78,7 +78,6 @@ jobs:
 
       - name: Install local HEAD
         id: install-package
-        env:
         shell: Rscript {0}
         run: |
           dl <- pak::local_install(

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -68,7 +68,7 @@ jobs:
             stop("No valid downloads found.")
           }
           untar(
-            tarfile = taget_tar,
+            tarfile = target_tar,
             exdir = dl[["package"]][[1L]]
           )
           cat(

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -87,7 +87,7 @@ jobs:
           tar -x -f "$REVDEP_FILE"
           AFTER=$(find . -maxdepth 1 -type d)
           echo "AFTER=$AFTER"
-          NEW_DIRS=$(comm -13 <(echo "$before") <(echo "$after"))
+          NEW_DIRS=$(comm -13 <(echo "$BEFORE") <(echo "$AFTER"))
           echo "NEW_DIRS=$NEW_DIRS"
           echo "revdep-dir=$NEW_DIRS"
           echo "revdep-dir=$NEW_DIRS" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -35,8 +35,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: 'devel'
-          http-user-agent: 'release'
+          r-version: devel
+          http-user-agent: release
           use-public-rspm: true
 
       - name: Download Reverse Dependency

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -84,9 +84,10 @@ jobs:
           REVDEP_FILE: ${{ steps.download-revdep.outputs.revdep-file }}
         run: |
           BEFORE=$(find . -maxdepth 1 -type d)
-          tar -xv -f "$REVDEP_FILE"
+          tar -x -f "$REVDEP_FILE"
           AFTER=$(find . -maxdepth 1 -type d)
           NEW_DIRS=$(comm -13 <(echo "$before") <(echo "$after"))
+          echo "revdep-dir=$NEW_DIRS"
           echo "revdep-dir=$NEW_DIRS" >> "$GITHUB_OUTPUT"
 
       - name: Install revdep dependencies

--- a/.github/workflows/R-revdeps.yml
+++ b/.github/workflows/R-revdeps.yml
@@ -101,7 +101,7 @@ jobs:
           cat .dirs_before
 
           if [ "$REVDEP_TYPE" = "github" ]; then
-            unzip "$REVDEP_FILE"
+            unzip -q "$REVDEP_FILE"
           else
             tar -x -f "$REVDEP_FILE"
           fi

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -33,6 +33,16 @@ on:
         required: false
         default: true
         type: boolean
+      do-revdeps-check:
+        description: 'Flag to run rcmdcheck on reverse dependencies. See revdeps input.'
+        required: false
+        default: true
+        type: boolean
+      revdeps:
+        description: 'JSON array of reverse dependencies, ex. [{"pkg": "r2dii.match"}, {"pkg": "RMI-PACTA/r2dii.match"}]'
+        required: false
+        default: '[]'
+        type: string
       r-cmd-check-error-on:
         description: 'Level of R CMD CHECK issue to fail check'
         required: false
@@ -101,3 +111,9 @@ jobs:
   deps-main-check:
     if: ${{ inputs.do-deps-main-check }}
     uses: ./.github/workflows/R-dep-main-check.yml
+
+  revdeps-check:
+    if: ${{ inputs.do-revdeps-check && inputs.revdeps }}
+    uses: ./.github/workflows/R-revdeps.yml
+    with:
+      revdeps: ${{ inputs.revdeps }}


### PR DESCRIPTION
Closes #95 

Adds a reverse dependency check for an R package. To use, call the workflow with the `revdeps` input taking a JSON array of objects with `pak` repo strings, ex:
```yml
jobs:
  R-package:
    name: R Package Checks
    uses: RMI-PACTA/actions/.github/workflows/R.yml@ci/95-r-rev-dep-check
    with:
      revdeps: |
          [
            {"pkg": "RMI-PACTA/r2dii.analysis"},
            {"pkg": "RMI-PACTA/r2dii.match"},
            {"pkg": "RMI-PACTA/r2dii.plot"},
            {"pkg": "r2dii.analysis"},
            {"pkg": "r2dii.match"}
            {"pkg": "r2dii.plot"}
          ]
```

which would add 6 jobs which will use `pak::pkg_download` to pull down the source of each package (here, 3 from GH, 3 from RSPM), install with their dependencies, then install the local package, and run `rcmdcheck::rcmdcheck` against the reverse dependency.

By default (not specifying `revdeps`), this check will not run (see [Actions](https://github.com/RMI-PACTA/r2dii.match/actions/runs/9571040645), [PR](https://github.com/RMI-PACTA/r2dii.match/pull/492/files/845a013852c96973a6200589bf07df6c1a1f8bdf))

See it in action: ([Actions](https://github.com/RMI-PACTA/r2dii.match/actions/runs/9571154490?pr=492), [PR](https://github.com/RMI-PACTA/r2dii.match/pull/492))

cc @RMI-PACTA/r-developers 