### PR TITLE
Use new codecov workflow

### DIFF
--- a/.github/workflows/R-codecov.yml
+++ b/.github/workflows/R-codecov.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/R-codecov.yml
+++ b/.github/workflows/R-codecov.yml
@@ -20,27 +20,36 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr
+          extra-packages: any::covr, any::xml2
           needs: coverage
 
       - name: Test coverage
         run: |
-          covr::codecov(
+          cov <- covr::package_coverage(
             quiet = FALSE,
             clean = FALSE,
             install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
           )
+          covr::to_cobertura(cov)
         shell: Rscript {0}
+
+      - uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' && true || false }}
+          file: ./cobertura.xml
+          plugin: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Show testthat output
         if: always()
         run: |
           ## --------------------------------------------------------------------
-          find ${{ runner.temp }}/package -name 'testthat.Rout*' -exec cat '{}' \; || true
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
         shell: bash
 
       - name: Upload test results
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures

--- a/.github/workflows/R-codecov.yml
+++ b/.github/workflows/R-codecov.yml
@@ -2,6 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: true
 
 name: codecov
 

--- a/.github/workflows/R-codecov.yml
+++ b/.github/workflows/R-codecov.yml
@@ -5,11 +5,14 @@ on:
 
 name: codecov
 
+permissions: read-all
+
 jobs:
   test-coverage:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/R-codecov.yml
+++ b/.github/workflows/R-codecov.yml
@@ -40,7 +40,7 @@ jobs:
         shell: bash
 
       - name: Upload test results
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -91,6 +91,9 @@ jobs:
   codecov:
     if: ${{ inputs.do-codecov }}
     uses: ./.github/workflows/R-codecov.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
 
   r-cmd-check:
     if: ${{ inputs.do-r-cmd-check }}

--- a/examples/R.yml
+++ b/examples/R.yml
@@ -20,3 +20,4 @@ jobs:
   R-package:
     name: R Package Checks
     uses: RMI-PACTA/actions/.github/workflows/R.yml@main
+    secrets: inherit


### PR DESCRIPTION
Update the codecov action to new workflow laidd out in `r-lib/actions`'s examples.

Of note for @RMI-PACTA/r-developers is that in the example file, I've added
```yml
  secrets: inherit
```

This grants the standard RMI-PACTA R action access to any repository secrets, but importantly, the org-level secrets that I've setup as well. This is necessary for communicating with some external services, such as codecov.io, and coming soon :tm: snyk.io .

The codecov workflow changed, as outlined here https://github.com/r-lib/actions/issues/834

See it in action at https://github.com/RMI-PACTA/pacta.workflow.utils/pull/15