### PR TITLE
Run codecov action on windows an MacOS

### DIFF
--- a/.github/workflows/R-codecov.yml
+++ b/.github/workflows/R-codecov.yml
@@ -12,7 +12,14 @@ permissions: read-all
 
 jobs:
   test-coverage:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - ubuntu-latest
+          - windows-latest
+          - macOS-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Adds Windows and MacOS runners for running codecov action, to deal with issues and tests that run differently on different platforms (i.e. `testthat::skip_on_os()`)

See it in action: https://github.com/RMI-PACTA/pacta.workflow.utils/pull/28