### PR TITLE
Remove `oldrel-4` from testing matrix

### DIFF
--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -62,8 +62,7 @@ on:
             {"os": "ubuntu-latest", "r": "devel", "http-user-agent": "release"},
             {"os": "ubuntu-latest", "r": "oldrel-1"},
             {"os": "ubuntu-latest", "r": "oldrel-2"},
-            {"os": "ubuntu-latest", "r": "oldrel-3"},
-            {"os": "ubuntu-latest", "r": "oldrel-4"}
+            {"os": "ubuntu-latest", "r": "oldrel-3"}
           ]
 
 


### PR DESCRIPTION
Currently, `oldrel-4` corresponds to `4.0.x`, but many of our packages depend on the native pipe (`|>`), introduced in `4.1.0`. 

Removing `4.0.x` from default testing matrix.

Tested in https://github.com/RMI-PACTA/workflow.pacta.report/pull/35