### PR TITLE
Add cyclocomp package to `lintr` runner

### DIFF
--- a/.github/workflows/R-lintr.yml
+++ b/.github/workflows/R-lintr.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::lintr, local::.
+          extra-packages: any::lintr, any::cyclocomp, local::.
           needs: lint
 
       - name: Lint


### PR DESCRIPTION
Cyclocomp was removed as a default dependency for `lintr`, but some of our packages have the linter enabled. 

Example: https://github.com/RMI-PACTA/workflow.pacta/actions/runs/14458315354

